### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/CriminalCourtFeeWaiver/data/questions/criminal_court_fee_waiver.yml
+++ b/docassemble/CriminalCourtFeeWaiver/data/questions/criminal_court_fee_waiver.yml
@@ -1629,9 +1629,9 @@ question: |
   Do you want to add your e-signature to your ${ form_name }?
 subquestion: |
   % if filing_basis != "filing_self":          
-  This program can put "**/s/ ${signer[0].name.full(middle="full")}**" where you would sign your name. The court will accept this as your signature.
+  This program can put "**/s/ ${signer[0].name_full()}**" where you would sign your name. The court will accept this as your signature.
   % else:
-  This program can put "**/s/ ${users[0].name.full(middle='full')}**" where you would sign your name. The court will accept this as your signature.
+  This program can put "**/s/ ${users[0].name_full()}**" where you would sign your name. The court will accept this as your signature.
   % endif
 
   If you do not add your **{e-signature}**, you must sign your paper form before you file it.
@@ -1697,9 +1697,9 @@ question: |
 signature: users[0].signature
 under: |
   % if filing_basis == "filing_self":
-    ${ users[0].name.full(middle="full") }
+    ${ users[0].name_full() }
   % else:
-    ${ signer[0].name.full(middle="full") }
+    ${ signer[0].name_full() }
   % endif
 ---
 id: court choice
@@ -1828,11 +1828,11 @@ attachments:
     editable: False
     fields:
       - "trial_court_county": ${ trial_court.address.county }
-      - "defendant": ${ defendants[0].name.full(middle="full") }      
+      - "defendant": ${ defendants[0].name_full() }      
       - "docket_number": ${ docket_number }
       - "docket_number__2": ${ docket_number }
       - "docket_number__3": ${ docket_number }
-      - "user_name_full": ${ users[0].name.full(middle="full") }
+      - "user_name_full": ${ users[0].name_full() }
 
 
   - name: IL fee waiver supplement
@@ -1847,9 +1847,9 @@ attachments:
       - "docket_number": ${ docket_number }
       - "signer_name_full": |
           % if filing_basis != "filing_self":
-          ${ signer[0].name.full(middle="full") }
+          ${ signer[0].name_full() }
           % else:
-          ${ users[0].name.full(middle="full") }
+          ${ users[0].name_full() }
           % endif
       - "signer_phone_number": |
           % if filing_basis != "filing_self":
@@ -1859,9 +1859,9 @@ attachments:
           % endif
       - "signer_signature_slash_s": |
           % if filing_basis != "filing_self":          
-          ${ "/s/ " + signer[0].name.full(middle="full") if e_signature else '' }
+          ${ "/s/ " + signer[0].name_full() if e_signature else '' }
           % else:
-          ${ "/s/ " + users[0].name.full(middle="full") if e_signature else ''  }
+          ${ "/s/ " + users[0].name_full() if e_signature else ''  }
           % endif
 
   - name: IL fee waiver petition
@@ -1872,14 +1872,14 @@ attachments:
     editable: False
     fields:
       - "trial_court_county": ${ trial_court.address.county }
-      - "defendant": ${ defendants[0].name.full(middle="full") }      
+      - "defendant": ${ defendants[0].name_full() }      
       - "docket_number": ${ docket_number }
       - "docket_number__1": ${ docket_number }
       - "docket_number__2": ${ docket_number }
       - "docket_number__3": ${ docket_number }
       - "filing_self_cb": ${ True if filing_basis == "filing_self" else ""}
       - "filing_obo_cb": ${ True if filing_basis != "filing_self" else ""}
-      - "user_name_full": ${ users[0].name.full(middle="full") }
+      - "user_name_full": ${ users[0].name_full() }
       - "user_address_one_line": ${ users[0].address.on_one_line(bare=True) }
       - "hide_address": |
           % if filing_basis != "filing_self":
@@ -1889,9 +1889,9 @@ attachments:
           % endif
       - "signer_name_full": |
           % if filing_basis != "filing_self":
-          ${ signer[0].name.full(middle="full") }
+          ${ signer[0].name_full() }
           % else:
-          ${ users[0].name.full(middle="full") }
+          ${ users[0].name_full() }
           % endif
       - "user_address_one_line__2": |
           % if filing_basis != "filing_self":
@@ -1902,9 +1902,9 @@ attachments:
 
       - "signer_signature_no_slash": |
           % if filing_basis != "filing_self":          
-          ${ signer[0].name.full(middle="full") if e_signature else '' }
+          ${ signer[0].name_full() if e_signature else '' }
           % else:
-          ${ users[0].name.full(middle="full") if e_signature else ''  }
+          ${ users[0].name_full() if e_signature else ''  }
           % endif
       - "signer_email": |
           % if filing_basis != "filing_self":
@@ -2206,12 +2206,12 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
     show if: filing_basis == "filing_self"
   - Edit: users[0].name.first
     button: |
       **Name of person you are filing for:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
     show if: filing_basis != "filing_self"
   - Edit: user_has_dependents
     button: |
@@ -2582,7 +2582,7 @@ review:
   - Edit: signer[0].name.first
     button: |
       **Your name:**
-      ${ signer[0].name.full(middle="full") }
+      ${ signer[0].name_full() }
     show if: filing_basis != "filing_self"
   - Edit: hide_signer_address
     button: |
@@ -3132,12 +3132,12 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
     show if: filing_basis == "filing_self"
   - Edit: users[0].name.first
     button: |
       **Name of person you are filing for:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
     show if: filing_basis != "filing_self"
   - Edit: 
       - trial_court_index
@@ -3167,12 +3167,12 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
     show if: filing_basis == "filing_self"
   - Edit: users[0].name.first
     button: |
       **Name of person you are filing for:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
     show if: filing_basis != "filing_self"
   - Edit: substantial_hardship_explanation
     button: |
@@ -3210,7 +3210,7 @@ review:
   - Edit: signer[0].name.first
     button: |
       **Your name:**
-      ${ signer[0].name.full(middle="full") }
+      ${ signer[0].name_full() }
     show if: filing_basis != "filing_self"
   - Edit: hide_signer_address
     button: |


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>